### PR TITLE
Implement basic Tetris game with CLI and tests

### DIFF
--- a/docs/fsm_diagram.md
+++ b/docs/fsm_diagram.md
@@ -1,0 +1,29 @@
+# Tetris Finite State Machine
+
+```
++---------+     start      +-------+
+|  START  |  ------------> | SPAWN |
++---------+                +-------+
+     ^                          |
+     | restart                  v
+     |                     +---------+
+     |                     |  MOVE   |
+     |                     +---------+
+     |      game over           |
+     |<-------------------------+
+     |                          v
+     |                     +-----------+
+     +---------------------| GAMEOVER |
+                           +-----------+
+```
+
+* **START** – awaiting the start command from user.
+* **SPAWN** – create a new falling piece and prepare preview of the next one. If
+  the piece cannot be placed, transition to **GAMEOVER**.
+* **MOVE** – main gameplay state. Handles user input (left, right, rotate,
+  down, drop). Each tick the piece moves one cell down. When the piece can no
+  longer move downward it is merged into the field and filled lines are cleared,
+  then transition back to **SPAWN**.
+* **GAMEOVER** – shown when a new piece cannot be spawned or user quits the
+  game. From here the game can be restarted by sending the start command.
+```

--- a/src/brick_game/tetris/tetris.c
+++ b/src/brick_game/tetris/tetris.c
@@ -1,13 +1,216 @@
 #include "tetris.h"
+
+#include <stdlib.h>
 #include <string.h>
 
-void init_game(GameInfo *game) {
-  if (game) {
-    memset(game->field, 0, sizeof(game->field));
+static GameInfo game;
+static UserAction last_action = ACT_NONE;
+static GameState state = STATE_START;
+static int next_shape = 0;
+
+// Definitions of all tetromino shapes in 4 rotations
+static const int shapes[7][4][4][4] = {
+    // I
+    {
+        {{0, 1, 0, 0}, {0, 1, 0, 0}, {0, 1, 0, 0}, {0, 1, 0, 0}},
+        {{0, 0, 0, 0}, {1, 1, 1, 1}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+        {{0, 1, 0, 0}, {0, 1, 0, 0}, {0, 1, 0, 0}, {0, 1, 0, 0}},
+        {{0, 0, 0, 0}, {1, 1, 1, 1}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+    },
+    // J
+    {
+        {{1, 0, 0, 0}, {1, 1, 1, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+        {{0, 1, 1, 0}, {0, 1, 0, 0}, {0, 1, 0, 0}, {0, 0, 0, 0}},
+        {{0, 0, 0, 0}, {1, 1, 1, 0}, {0, 0, 1, 0}, {0, 0, 0, 0}},
+        {{0, 1, 0, 0}, {0, 1, 0, 0}, {1, 1, 0, 0}, {0, 0, 0, 0}},
+    },
+    // L
+    {
+        {{0, 0, 1, 0}, {1, 1, 1, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+        {{0, 1, 0, 0}, {0, 1, 0, 0}, {0, 1, 1, 0}, {0, 0, 0, 0}},
+        {{0, 0, 0, 0}, {1, 1, 1, 0}, {1, 0, 0, 0}, {0, 0, 0, 0}},
+        {{1, 1, 0, 0}, {0, 1, 0, 0}, {0, 1, 0, 0}, {0, 0, 0, 0}},
+    },
+    // O
+    {
+        {{0, 1, 1, 0}, {0, 1, 1, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+        {{0, 1, 1, 0}, {0, 1, 1, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+        {{0, 1, 1, 0}, {0, 1, 1, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+        {{0, 1, 1, 0}, {0, 1, 1, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+    },
+    // S
+    {
+        {{0, 1, 1, 0}, {1, 1, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+        {{0, 1, 0, 0}, {0, 1, 1, 0}, {0, 0, 1, 0}, {0, 0, 0, 0}},
+        {{0, 1, 1, 0}, {1, 1, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+        {{0, 1, 0, 0}, {0, 1, 1, 0}, {0, 0, 1, 0}, {0, 0, 0, 0}},
+    },
+    // T
+    {
+        {{0, 1, 0, 0}, {1, 1, 1, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+        {{0, 1, 0, 0}, {0, 1, 1, 0}, {0, 1, 0, 0}, {0, 0, 0, 0}},
+        {{0, 0, 0, 0}, {1, 1, 1, 0}, {0, 1, 0, 0}, {0, 0, 0, 0}},
+        {{0, 1, 0, 0}, {1, 1, 0, 0}, {0, 1, 0, 0}, {0, 0, 0, 0}},
+    },
+    // Z
+    {
+        {{1, 1, 0, 0}, {0, 1, 1, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+        {{0, 0, 1, 0}, {0, 1, 1, 0}, {0, 1, 0, 0}, {0, 0, 0, 0}},
+        {{1, 1, 0, 0}, {0, 1, 1, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+        {{0, 0, 1, 0}, {0, 1, 1, 0}, {0, 1, 0, 0}, {0, 0, 0, 0}},
+    },
+};
+
+static void copy_next_preview(void) {
+  for (int i = 0; i < 4; ++i)
+    for (int j = 0; j < 4; ++j)
+      game.next[i][j] = shapes[next_shape][0][i][j];
+}
+
+static void reset_game(void) {
+  memset(&game, 0, sizeof(game));
+  next_shape = 0;
+  copy_next_preview();
+}
+
+static int check_collision(int x, int y, int shape, int rot) {
+  for (int i = 0; i < 4; ++i) {
+    for (int j = 0; j < 4; ++j) {
+      if (shapes[shape][rot][i][j]) {
+        int nx = x + j;
+        int ny = y + i;
+        if (nx < 0 || nx >= FIELD_WIDTH || ny < 0 || ny >= FIELD_HEIGHT)
+          return 1;
+        if (game.field[ny][nx]) return 1;
+      }
+    }
+  }
+  return 0;
+}
+
+static void place_piece(void) {
+  const int (*shape)[4] = shapes[game.current_shape][game.rotation];
+  for (int i = 0; i < 4; ++i)
+    for (int j = 0; j < 4; ++j)
+      if (shape[i][j]) game.field[game.current_y + i][game.current_x + j] = game.current_shape + 1;
+}
+
+static void remove_piece(void) {
+  const int (*shape)[4] = shapes[game.current_shape][game.rotation];
+  for (int i = 0; i < 4; ++i)
+    for (int j = 0; j < 4; ++j)
+      if (shape[i][j]) game.field[game.current_y + i][game.current_x + j] = 0;
+}
+
+static void spawn_piece(void) {
+  game.current_shape = next_shape;
+  next_shape = (next_shape + 1) % 7;
+  copy_next_preview();
+  game.rotation = 0;
+  game.current_x = FIELD_WIDTH / 2 - 2;
+  game.current_y = 0;
+  if (check_collision(game.current_x, game.current_y, game.current_shape, game.rotation)) {
+    game.game_over = 1;
+    state = STATE_GAMEOVER;
+    return;
+  }
+  place_piece();
+}
+
+static int try_move(int dx, int dy) {
+  remove_piece();
+  int new_x = game.current_x + dx;
+  int new_y = game.current_y + dy;
+  if (!check_collision(new_x, new_y, game.current_shape, game.rotation)) {
+    game.current_x = new_x;
+    game.current_y = new_y;
+    place_piece();
+    return 1;
+  }
+  place_piece();
+  return 0;
+}
+
+static void try_rotate(void) {
+  remove_piece();
+  int new_rot = (game.rotation + 1) % 4;
+  if (!check_collision(game.current_x, game.current_y, game.current_shape, new_rot))
+    game.rotation = new_rot;
+  place_piece();
+}
+
+static void hard_drop(void) {
+  remove_piece();
+  while (!check_collision(game.current_x, game.current_y + 1, game.current_shape, game.rotation))
+    game.current_y++;
+  place_piece();
+}
+
+static void clear_lines(void) {
+  for (int i = FIELD_HEIGHT - 1; i >= 0; --i) {
+    int full = 1;
+    for (int j = 0; j < FIELD_WIDTH; ++j) {
+      if (game.field[i][j] == 0) {
+        full = 0;
+        break;
+      }
+    }
+    if (full) {
+      for (int k = i; k > 0; --k)
+        memcpy(game.field[k], game.field[k - 1], sizeof(game.field[0]));
+      memset(game.field[0], 0, sizeof(game.field[0]));
+      i++;  // recheck same row after shifting
+    }
   }
 }
 
-void step_game(GameInfo *game) {
-  // Placeholder for game logic
-  (void)game;
+void userInput(UserAction action) { last_action = action; }
+
+GameInfo updateCurrentState(void) {
+  switch (state) {
+    case STATE_START:
+      if (last_action == ACT_START) {
+        reset_game();
+        state = STATE_SPAWN;
+      }
+      break;
+    case STATE_SPAWN:
+      spawn_piece();
+      if (state != STATE_GAMEOVER) state = STATE_MOVE;
+      break;
+    case STATE_MOVE:
+      if (last_action == ACT_LEFT) {
+        try_move(-1, 0);
+      } else if (last_action == ACT_RIGHT) {
+        try_move(1, 0);
+      } else if (last_action == ACT_ROTATE) {
+        try_rotate();
+      } else if (last_action == ACT_DOWN) {
+        try_move(0, 1);
+      } else if (last_action == ACT_DROP) {
+        hard_drop();
+      } else if (last_action == ACT_QUIT) {
+        game.game_over = 1;
+        state = STATE_GAMEOVER;
+      }
+      if (!try_move(0, 1)) {
+        place_piece();
+        clear_lines();
+        if (state != STATE_GAMEOVER) state = STATE_SPAWN;
+      }
+      break;
+    case STATE_GAMEOVER:
+      if (last_action == ACT_START) {
+        reset_game();
+        state = STATE_SPAWN;
+        game.game_over = 0;
+      }
+      break;
+  }
+  last_action = ACT_NONE;
+  return game;
 }
+
+__attribute__((constructor)) static void init_module(void) { reset_game(); }
+
+GameInfo *getGame(void) { return &game; }

--- a/src/brick_game/tetris/tetris.h
+++ b/src/brick_game/tetris/tetris.h
@@ -1,14 +1,50 @@
 #ifndef TETRIS_H
 #define TETRIS_H
 
+#include <stdbool.h>
+
 #define FIELD_WIDTH 10
 #define FIELD_HEIGHT 20
 
+// User actions that can be sent from interface to the library
+typedef enum {
+  ACT_NONE,
+  ACT_LEFT,
+  ACT_RIGHT,
+  ACT_DOWN,
+  ACT_DROP,
+  ACT_ROTATE,
+  ACT_START,
+  ACT_PAUSE,
+  ACT_QUIT
+} UserAction;
+
+// Internal state of the game
+typedef enum {
+  STATE_START,
+  STATE_SPAWN,
+  STATE_MOVE,
+  STATE_GAMEOVER
+} GameState;
+
+// Structure describing the current game field and additional information
 typedef struct {
-  int field[FIELD_HEIGHT][FIELD_WIDTH];
+  int field[FIELD_HEIGHT][FIELD_WIDTH];  // play field including moving block
+  int next[4][4];                        // preview of next block
+  int current_x;
+  int current_y;
+  int current_shape;
+  int rotation;
+  int game_over;  // 1 when game finished
 } GameInfo;
 
-void init_game(GameInfo *game);
-void step_game(GameInfo *game);
+// Receive user input. The action will be processed on next updateCurrentState()
+void userInput(UserAction action);
+
+// Perform one step of the finite state machine and return current game state
+GameInfo updateCurrentState(void);
+
+// Direct access to internal game state (useful for tests)
+GameInfo *getGame(void);
 
 #endif  // TETRIS_H

--- a/src/gui/cli/main.c
+++ b/src/gui/cli/main.c
@@ -1,18 +1,68 @@
+#define _XOPEN_SOURCE 500
 #include <ncurses.h>
+#include <unistd.h>
 #include "../../brick_game/tetris/tetris.h"
 
-int main(void) {
-  GameInfo game;
-  init_game(&game);
+static void draw_game(const GameInfo *g) {
+  clear();
+  for (int i = 0; i < FIELD_HEIGHT; ++i) {
+    for (int j = 0; j < FIELD_WIDTH; ++j) {
+      mvprintw(i, j * 2, g->field[i][j] ? "[]" : " .");
+    }
+  }
+  mvprintw(0, FIELD_WIDTH * 2 + 2, "Next:");
+  for (int i = 0; i < 4; ++i) {
+    for (int j = 0; j < 4; ++j) {
+      mvprintw(1 + i, FIELD_WIDTH * 2 + 2 + j * 2,
+               g->next[i][j] ? "[]" : "  ");
+    }
+  }
+  if (g->game_over) mvprintw(FIELD_HEIGHT / 2, FIELD_WIDTH, "GAME OVER");
+  refresh();
+}
 
+int main(void) {
   initscr();
   noecho();
   curs_set(FALSE);
+  keypad(stdscr, TRUE);
+  nodelay(stdscr, TRUE);
+  timeout(0);
 
-  mvprintw(0, 0, "Tetris stub. Field %dx%d", FIELD_WIDTH, FIELD_HEIGHT);
+  userInput(ACT_START);
+  while (1) {
+    int ch = getch();
+    if (ch != ERR) {
+      switch (ch) {
+        case KEY_LEFT:
+          userInput(ACT_LEFT);
+          break;
+        case KEY_RIGHT:
+          userInput(ACT_RIGHT);
+          break;
+        case KEY_DOWN:
+          userInput(ACT_DOWN);
+          break;
+        case ' ':
+          userInput(ACT_ROTATE);
+          break;
+        case '\n':
+          userInput(ACT_DROP);
+          break;
+        case 'q':
+          userInput(ACT_QUIT);
+          break;
+      }
+    }
+    GameInfo g = updateCurrentState();
+    draw_game(&g);
+    if (g.game_over) break;
+    usleep(50000);
+  }
+  nodelay(stdscr, FALSE);
+  mvprintw(FIELD_HEIGHT + 1, 0, "Press any key to exit");
   refresh();
   getch();
-
   endwin();
   return 0;
 }

--- a/tests/test_tetris.c
+++ b/tests/test_tetris.c
@@ -1,0 +1,61 @@
+#include <assert.h>
+#include "../src/brick_game/tetris/tetris.h"
+
+void start_and_spawn(void) {
+  userInput(ACT_QUIT); updateCurrentState();
+  userInput(ACT_QUIT); updateCurrentState();
+  userInput(ACT_START); updateCurrentState();
+  GameInfo g = updateCurrentState();
+  assert(g.field[0][4] == 1);
+  assert(g.field[3][4] == 1);
+}
+
+void move_and_rotate(void) {
+  userInput(ACT_QUIT); updateCurrentState();
+  userInput(ACT_QUIT); updateCurrentState();
+  userInput(ACT_START); updateCurrentState();
+  updateCurrentState();
+  userInput(ACT_LEFT);
+  GameInfo g = updateCurrentState();
+  assert(g.field[1][3] == 1);
+  userInput(ACT_ROTATE);
+  g = updateCurrentState();
+  assert(g.field[3][2] == 1);
+  assert(g.field[3][5] == 1);
+}
+
+void line_clear(void) {
+  userInput(ACT_QUIT); updateCurrentState();
+  userInput(ACT_QUIT); updateCurrentState();
+  userInput(ACT_START); updateCurrentState();
+  updateCurrentState();
+  GameInfo *gp = getGame();
+  for (int j = 0; j < FIELD_WIDTH; ++j) {
+    if (j < 3 || j > 6) gp->field[FIELD_HEIGHT - 1][j] = 7;
+  }
+  userInput(ACT_ROTATE);
+  updateCurrentState();
+  userInput(ACT_DROP);
+  GameInfo g = updateCurrentState();
+  int empty = 1;
+  for (int j = 0; j < FIELD_WIDTH; ++j) empty &= (g.field[FIELD_HEIGHT - 1][j] == 0);
+  assert(empty == 1);
+}
+
+void game_over_state(void) {
+  userInput(ACT_QUIT); updateCurrentState();
+  userInput(ACT_QUIT); updateCurrentState();
+  userInput(ACT_START); updateCurrentState();  // move to spawn state
+  GameInfo *gp = getGame();
+  for (int j = 0; j < FIELD_WIDTH; ++j) gp->field[0][j] = 7;
+  GameInfo g = updateCurrentState();
+  assert(g.game_over == 1);
+}
+
+int main(void) {
+  start_and_spawn();
+  move_and_rotate();
+  line_clear();
+  game_over_state();
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add finite state machine based Tetris engine with piece movement, rotation, hard drop, line clearing and game-over detection
- provide ncurses CLI to render field and handle user controls
- supply unit tests and coverage harness for core game logic
- document state machine diagram

## Testing
- `make test`
- `make gcov_report`


------
https://chatgpt.com/codex/tasks/task_e_68bc1fd6d79c832c9bf58ff5309570cb