### PR TITLE
Add pause mode and separate drop speed

### DIFF
--- a/src/brick_game/tetris/tetris.h
+++ b/src/brick_game/tetris/tetris.h
@@ -24,6 +24,7 @@ typedef enum {
   STATE_START,
   STATE_SPAWN,
   STATE_MOVE,
+  STATE_PAUSE,
   STATE_GAMEOVER
 } GameState;
 
@@ -38,6 +39,7 @@ typedef struct {
   int game_over;  // 1 when game finished
   int score;      // current score
   int high_score; // maximum stored score
+  int paused;     // 1 when game is paused
 } GameInfo;
 
 // Receive user input. The action will be processed on next updateCurrentState()
@@ -48,5 +50,8 @@ GameInfo updateCurrentState(void);
 
 // Direct access to internal game state (useful for tests)
 GameInfo *getGame(void);
+
+// Set number of update ticks between automatic downward moves
+void setFallSpeed(int delay);
 
 #endif  // TETRIS_H

--- a/src/gui/cli/main.c
+++ b/src/gui/cli/main.c
@@ -19,7 +19,10 @@ static void draw_game(const GameInfo *g) {
   }
   mvprintw(6, FIELD_WIDTH * 2 + 2, "Score: %d", g->score);
   mvprintw(7, FIELD_WIDTH * 2 + 2, "High: %d", g->high_score);
-  if (g->game_over) mvprintw(FIELD_HEIGHT / 2, FIELD_WIDTH, "GAME OVER");
+  if (g->game_over)
+    mvprintw(FIELD_HEIGHT / 2, FIELD_WIDTH, "GAME OVER");
+  else if (g->paused)
+    mvprintw(FIELD_HEIGHT / 2, FIELD_WIDTH, "PAUSED");
   refresh();
 }
 
@@ -31,6 +34,7 @@ int main(void) {
   nodelay(stdscr, TRUE);
   timeout(0);
 
+  setFallSpeed(20);
   userInput(ACT_START);
   while (1) {
     int ch = getch();
@@ -53,6 +57,10 @@ int main(void) {
           break;
         case 'q':
           userInput(ACT_QUIT);
+          break;
+        case 'p':
+        case 'P':
+          userInput(ACT_PAUSE);
           break;
       }
     }

--- a/tests/test_tetris.c
+++ b/tests/test_tetris.c
@@ -21,8 +21,8 @@ void move_and_rotate(void) {
   assert(g.field[1][3] == 1);
   userInput(ACT_ROTATE);
   g = updateCurrentState();
-  assert(g.field[3][2] == 1);
-  assert(g.field[3][5] == 1);
+  assert(g.field[1][2] == 1);
+  assert(g.field[1][5] == 1);
 }
 
 void line_clear(void) {
@@ -77,11 +77,30 @@ void score_and_highscore(void) {
   assert(g.high_score == 100);
 }
 
+void pause_functionality(void) {
+  userInput(ACT_QUIT); updateCurrentState();
+  userInput(ACT_QUIT); updateCurrentState();
+  userInput(ACT_START); updateCurrentState();
+  updateCurrentState();
+  GameInfo g = updateCurrentState();
+  int x = g.current_x;
+  int y = g.current_y;
+  userInput(ACT_PAUSE); updateCurrentState();
+  userInput(ACT_LEFT); g = updateCurrentState();
+  assert(g.paused == 1);
+  assert(g.current_x == x && g.current_y == y);
+  userInput(ACT_PAUSE); updateCurrentState();
+  userInput(ACT_DOWN); g = updateCurrentState();
+  assert(g.paused == 0);
+  assert(g.current_y == y + 1);
+}
+
 int main(void) {
   start_and_spawn();
   move_and_rotate();
   line_clear();
   game_over_state();
   score_and_highscore();
+  pause_functionality();
   return 0;
 }


### PR DESCRIPTION
## Summary
- Support pausing gameplay with `P` and show "PAUSED" overlay
- Decouple piece drop rate from interface update rate with configurable fall speed
- Cover new pause behaviour with unit test

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bc2bbe6370832cb0a30fc8cd25041b