### PR TITLE
Improve level mechanics in CLI tetris

### DIFF
--- a/src/brick_game/tetris/tetris.c
+++ b/src/brick_game/tetris/tetris.c
@@ -12,6 +12,7 @@ static const char *score_file = "highscore.dat";
 static int base_fall_delay = 20;
 static int fall_delay = 20;
 static int fall_counter = 0;
+static const int level_speedup = 2;
 
 // Definitions of all tetromino shapes in 4 rotations
 static const int shapes[7][4][4][4] = {
@@ -75,7 +76,8 @@ static void copy_next_preview(void) {
 void setFallSpeed(int delay) {
   if (delay > 0) {
     base_fall_delay = delay;
-    fall_delay = base_fall_delay - (game.level > 0 ? game.level - 1 : 0);
+    fall_delay =
+        base_fall_delay - (game.level > 0 ? (game.level - 1) * level_speedup : 0);
     if (fall_delay < 1) fall_delay = 1;
   }
 }
@@ -114,7 +116,7 @@ static void update_level(void) {
   if (new_level > 10) new_level = 10;
   if (new_level != game.level) {
     game.level = new_level;
-    fall_delay = base_fall_delay - (game.level - 1);
+    fall_delay = base_fall_delay - (game.level - 1) * level_speedup;
     if (fall_delay < 1) fall_delay = 1;
     fall_counter = 0;
   }

--- a/src/gui/cli/main.c
+++ b/src/gui/cli/main.c
@@ -19,6 +19,7 @@ static void draw_game(const GameInfo *g) {
   }
   mvprintw(6, FIELD_WIDTH * 2 + 2, "Score: %d", g->score);
   mvprintw(7, FIELD_WIDTH * 2 + 2, "High: %d", g->high_score);
+  mvprintw(8, FIELD_WIDTH * 2 + 2, "Level: %d", g->level);
   if (g->game_over)
     mvprintw(FIELD_HEIGHT / 2, FIELD_WIDTH, "GAME OVER");
   else if (g->paused)


### PR DESCRIPTION
## Summary
- accelerate piece fall speed by two ticks per level
- show current level beside score and high score in the CLI

## Testing
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bc3853fac0832c9a30911b4194ccff